### PR TITLE
chore: python-http-jxboot-20200220001 to 0.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -21,4 +21,4 @@ dependencies:
   version: 0.0.4
 - name: python-http-jxboot-20200220001
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.5
+  version: 0.0.6


### PR DESCRIPTION
chore: Promote python-http-jxboot-20200220001 to version 0.0.6